### PR TITLE
Remove references to the old verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you are a BrowserID whiz and prefer to do your own thing, include only the `/
     , "audience" : "example.com:80"
     }
 
-The response will be the same as `https://browserid.org/verify`. That URL is currently used for verification. You can use a different one by changing `/_config/httpd/browserid_verify_url`.
+The response will be the same as `https://verifier.login.persona.org/verify`. That URL is currently used for verification. You can use a different one by changing `/_config/httpd/browserid_verify_url`.
 
 ## Building
 

--- a/src/couch_httpd_browserid.erl
+++ b/src/couch_httpd_browserid.erl
@@ -141,7 +141,7 @@ verify_id_with_crutch(VerifyURL, Assertion, Audience) ->
     VerifyQS = "assertion=" ++ Assertion ++ "&audience=" ++ Audience,
 
     %% VerifyURL = ?l2b(couch_util:get_value("verify_url", Form,
-    %%                                       "https://browserid.org/verify")),
+    %%                                       "https://verifier.login.persona.org/verify")),
     %% case ibrowse_lib:parse_url(VerifyUrl) of
     %% #url{protocol = https} ->
     %%     % Maybe don't allow non-https providers?


### PR DESCRIPTION
The old verifier at browserid.org is deprecated and will stop
working at some point.
