### PR TITLE
Replace deprecated .getVerifiedEmail() with .get()

### DIFF
--- a/priv/main.js
+++ b/priv/main.js
@@ -89,7 +89,7 @@ $(document).ready(function() {
 
 function start_login() {
   $("#browserid .login").addClass('pending');
-  navigator.id.getVerifiedEmail(gotVerifiedEmail);
+  navigator.id.get(gotVerifiedEmail);
 }
 
 


### PR DESCRIPTION
This changes will eliminate a console warning.
