### PR TITLE
Stop sending a user-supplied audience to the backend

### DIFF
--- a/priv/main.js
+++ b/priv/main.js
@@ -24,7 +24,6 @@ function gotVerifiedEmail(assertion) {
       url = window.BROWSERID_URL;
 
     var to_verify = { 'assertion': window.encodeURIComponent(assertion)
-                    , 'audience' : window.encodeURIComponent(window.location.host)
                     };
 
     $.ajax({


### PR DESCRIPTION
As explained in issue #16, this paremeter is not used but being
there means that it could lead to a security bug in the future if
it ever gets used.
