### PR TITLE
Support building with prebuild CouchDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,21 @@
-# Customize here
 NAME=browserid_couchdb
-VERSION=1.0.0
-# Stop customizing here
-
-ERL=$(shell couch-config --erl-bin)
-ERLANG_VERSION=$(shell couch-config --erlang-version)
 COUCHDB_VERSION=$(shell couch-config --couch-version | sed 's/\+.*//')
 PLUGIN_DIRS=ebin priv
-PLUGIN_VERSION_SLUG=$(NAME)-$(VERSION)-$(ERLANG_VERSION)-$(COUCHDB_VERSION)
-PLUGIN_DIST=$(PLUGIN_VERSION_SLUG)
-
+PLUGIN_DEST=$(shell couch-config --erl-libs-dir)/$(NAME)
+CONFIG_FILES=etc/couchdb/default.d/*.ini 
+ERL_COMPILER_OPTIONS=[{i, "$(shell couch-config --erl-libs-dir)/couch-$(COUCHDB_VERSION)/include"}]
 all: compile
 
 compile:
-	ERL_LIBS=$(shell couch-config --erl-libs-dir):$(ERL_LIBS) rebar compile
+	@ERL_LIBS=$(shell couch-config --erl-libs-dir):$(ERL_LIBS) rebar compile
 
 dev:
-	@ERL_LIBS=$(shell pwd) couchdb -i -a priv/default.d/*.ini
+	@ERL_LIBS=$(shell pwd) couchdb -i -a $(CONFIG_FILES)
 
-plugin: compile
-	@mkdir -p $(PLUGIN_DIRS)
-	@mkdir -p $(PLUGIN_DIST)
-	@cp -r $(PLUGIN_DIRS) $(PLUGIN_DIST)
-	@tar czf $(PLUGIN_VERSION_SLUG).tar.gz $(PLUGIN_DIST)
-	@$(ERL) -eval 'File = "$(PLUGIN_VERSION_SLUG).tar.gz", {ok, Data} = file:read_file(File),io:format("~s: ~s~n", [File, base64:encode(crypto:sha(Data))]),halt()' -noshell
+install: compile
+	@mkdir -p $(PLUGIN_DEST)
+	@cp -r $(PLUGIN_DIRS) $(PLUGIN_DEST)/
+	@cp $(CONFIG_FILES) $(shell couch-config --config-dir)/default.d/
+
+clean:
+	@rm -rf ebin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COUCHDB_VERSION=$(shell couch-config --couch-version | sed 's/\+.*//')
 PLUGIN_DIRS=ebin priv
 PLUGIN_DEST=$(shell couch-config --erl-libs-dir)/$(NAME)
 CONFIG_FILES=etc/couchdb/default.d/*.ini 
-ERL_COMPILER_OPTIONS=[{i, "$(shell couch-config --erl-libs-dir)/couch-$(COUCHDB_VERSION)/include"}]
+ERL_COMPILER_OPTIONS="[{i, \"$(shell couch-config --erl-libs-dir)/couch-$(COUCHDB_VERSION)/include\"}]"
 all: compile
 
 compile:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Customize here
+NAME=browserid_couchdb
+VERSION=1.0.0
+# Stop customizing here
+
+ERL=$(shell couch-config --erl-bin)
+ERLANG_VERSION=$(shell couch-config --erlang-version)
+COUCHDB_VERSION=$(shell couch-config --couch-version | sed 's/\+.*//')
+PLUGIN_DIRS=ebin priv
+PLUGIN_VERSION_SLUG=$(NAME)-$(VERSION)-$(ERLANG_VERSION)-$(COUCHDB_VERSION)
+PLUGIN_DIST=$(PLUGIN_VERSION_SLUG)
+
+all: compile
+
+compile:
+	ERL_LIBS=$(shell couch-config --erl-libs-dir):$(ERL_LIBS) rebar compile
+
+dev:
+	@ERL_LIBS=$(shell pwd) couchdb -i -a priv/default.d/*.ini
+
+plugin: compile
+	@mkdir -p $(PLUGIN_DIRS)
+	@mkdir -p $(PLUGIN_DIST)
+	@cp -r $(PLUGIN_DIRS) $(PLUGIN_DIST)
+	@tar czf $(PLUGIN_VERSION_SLUG).tar.gz $(PLUGIN_DIST)
+	@$(ERL) -eval 'File = "$(PLUGIN_VERSION_SLUG).tar.gz", {ok, Data} = file:read_file(File),io:format("~s: ~s~n", [File, base64:encode(crypto:sha(Data))]),halt()' -noshell

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,6 @@
+%%-*- mode: erlang -*-
+{deps, [
+  {ibrowse, "2.1.3",
+    {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v2.2.0"}}}
+]}.
+

--- a/src/couch_httpd_browserid.erl
+++ b/src/couch_httpd_browserid.erl
@@ -12,7 +12,7 @@
 
 -module(couch_httpd_browserid).
 -include("couch_db.hrl").
--include("../ibrowse/ibrowse.hrl").
+-include("deps/ibrowse/src/ibrowse.hrl").
 
 -export([handle_id_req/1]).
 


### PR DESCRIPTION
This branch is the result of several hours getting this plugin installed into a prebuilt CouchDB.

It includes a Makefile, and one change to include a dependency via rebar.

I tested with OSX 10.9 and `brew install couchdb` but it should work with other packaged builds (ubuntu, official).

Telling people to use `build-couchdb` is not very friendly when it rebuilds Erlang on every run.
